### PR TITLE
Fix: Update lychee exclusions in broken-links workflow

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -49,4 +49,4 @@ jobs:
         with:
           fail: true
           # removed md files that include liquid tags
-          args: --user-agent 'curl/7.54' --exclude-path README.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path _posts/2018-12-22-distill.md --verbose --no-progress './**/*.md' './**/*.html'
+          args: --user-agent 'curl/7.54' --exclude-path README.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path _posts/2018-12-22-distill.md --exclude-path _drafts/blog.md --exclude-path _drafts/2018-12-22-distill.md --exclude https://stackoverflow.com/questions/34987908/embed-a-code-block-in-a-list-item-with-proper-indentation-in-kramdown/38090598#38090598 --exclude https://www.altmetric.com/ --exclude https://twitter.com/rubygems/status/518821243320287232 --exclude https://twitter.com/jekyllrb --verbose --no-progress './**/*.md' './**/*.html'


### PR DESCRIPTION
The lychee link checker was failing due to a few reasons:
- Checking draft files with unresolved Liquid tags (e.g., _drafts/blog.md, _drafts/2018-12-22-distill.md), leading to file-not-found errors for templated paths.
- External sites (Stack Overflow, Altmetric, Twitter) returning 403 errors or network errors, possibly due to anti-scraping measures or issues with intermediate services like Nitter.

This commit updates the lychee arguments in the .github/workflows/broken-links.yml file to:
- Add _drafts/blog.md and _drafts/2018-12-22-distill.md to the --exclude-path list.
- Add specific problematic URLs for Stack Overflow, Altmetric, and Twitter to the --exclude list.

These changes should prevent the link checker from failing on these known issues.