### PR TITLE
Fix Imagemagick errors in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,10 @@ jobs:
           valueFile: "_config.yml"
           propertyPath: "giscus.repo"
           value: ${{ github.repository }}
+      - name: Install ImageMagick 🖼️
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y imagemagick
       - name: Install and Build 🔧
         run: |
           pip3 install --upgrade jupyter


### PR DESCRIPTION
## Summary
- ensure ImageMagick is installed when running the deploy workflow

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_683f3e8d2ac0832981dab04223b4d398